### PR TITLE
Fix `phase_fraction` scalar handling

### DIFF
--- a/src/imgen.jl
+++ b/src/imgen.jl
@@ -75,8 +75,12 @@ function trim_nonpercolating_paths(img; axis)
     return img_percolating
 end
 
-function phase_fraction(img, labels)
-    return sum(sum(img .== label) for label in labels) / length(img)
+function phase_fraction(img, label)
+    return count(img .== label) / length(img)
+end
+
+function phase_fraction(img, labels::AbstractArray)
+    return sum(phase_fraction(img, label) for label in labels)
 end
 
 function phase_fraction(img)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -33,4 +33,10 @@ img[:, :, 21:32] .= 5
         @test phase_fraction(img, [0, 1, 5]) ≈ ε0 + ε1 + ε5 atol=1e-4
     end
 
+    @testset "Scalar and array inputs match" begin
+        @test phase_fraction(img, [0]) ≈ phase_fraction(img, 0) atol=1e-4
+        @test phase_fraction(img, [1]) ≈ phase_fraction(img, 1) atol=1e-4
+        @test phase_fraction(img, [5]) ≈ phase_fraction(img, 5) atol=1e-4
+    end
+
 end


### PR DESCRIPTION
## Summary
- handle single label inputs in `Imaginator.phase_fraction`
- test for scalar vs array consistency

## Testing
- `julia -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687016dbddec8333a2b5868252cd8f68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy and clarity of phase fraction calculations for both single and multiple labels.

* **Tests**
  * Added tests to ensure consistent results when using scalar and single-element array inputs for phase fraction calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->