### PR TITLE
Add boolean index helper tests

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -40,3 +40,19 @@ img[:, :, 21:32] .= 5
     end
 
 end
+
+@testset "Boolean index helpers" begin
+    mat = Bool[
+        true  false;
+        false true;
+        true  true
+    ]
+    expected = LinearIndices(mat)[findall(mat)]
+
+    @test find_true_indices(mat) == expected
+
+    lookup = reverse_lookup(mat)
+    for (i, idx) in enumerate(expected)
+        @test lookup[idx] == i
+    end
+end


### PR DESCRIPTION
## Summary
- extend utils tests with coverage for `find_true_indices` and `reverse_lookup`

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'` *(fails: julia not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68701d16a7408333ba7e7ebef8821aee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to validate helper functions for Boolean indexing, ensuring correct identification and lookup of true element indices in Boolean matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->