### PR TITLE
Fix variable name in utils

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,7 +69,7 @@ function get_taufactor_conc(tau_solver; fill_value=NaN, normalize=true)
     img = pyconvert(Array, tau_solver.cpu_img.squeeze())
     # NOTE: TauFactor always solves along the x-axis
     img_padded = pad(img, :replicate, (1, 0, 0))
-    c = isa(c, Py) ? pyconvert(Array, tausolver.conc.squeeze().numpy()) : c
+    c = isa(c, Py) ? pyconvert(Array, tau_solver.conc.squeeze().numpy()) : c
     # Hardcode BC values; taufactor doesn't update them
     c[1, :, :] .= 0.5
     c[end, :, :] .= -0.5


### PR DESCRIPTION
## Summary
- correct variable name `tausolver` to `tau_solver` in `get_taufactor_conc`

## Testing
- `julia --project=@. -e 'using Pkg; Pkg.test()'` *(fails: precompilation hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68701cfd3aa88333adfa5df89ce96878