### PR TITLE
fix: correct half-voxel offset in `depth_actual` for `:conc` / `:flux` fits

### DIFF
--- a/src/transient_fitting.jl
+++ b/src/transient_fitting.jl
@@ -58,10 +58,11 @@ function fit_effective_diffusivity(
     L = (N - 1) * prob.voxel_size * (insulated ? 2 : 1)
 
     if method == :conc
-        # Cell-center convention: concentration lives at the center of each voxel,
-        # so voxel index i maps to physical position (i - 0.5) * voxel_size.
+        # Cell-centered FV with Dirichlet clamped at the centers of voxels 1
+        # and N, so in the analytical coordinate those live at x=0 and x=L
+        # respectively. Voxel i therefore sits at (i - 1) * voxel_size.
         depth_idx = round(Int, 1 + depth * (N - 1))
-        depth_actual = (depth_idx - 0.5) * prob.voxel_size
+        depth_actual = (depth_idx - 1) * prob.voxel_size
 
         ydata = slice_concentration(
             c_hist[idx_min:idx_max], prob.img, prob.axis, depth_idx;
@@ -74,13 +75,15 @@ function fit_effective_diffusivity(
         model = (t, p) -> φ * (c1 + c2) / 2 .* slab_mass_uptake(p[1], t; c1=c1, c2=c2, L=L, terms=terms)
 
     elseif method == :flux
-        # Cell-face convention: flux is computed at the face between voxels
-        # depth_idx and depth_idx+1, so the physical position is depth_idx * voxel_size.
+        # Flux is evaluated between voxels depth_idx and depth_idx+1, at the
+        # face midpoint between their centers. In the analytical coordinate
+        # that face sits at (depth_idx - 0.5) * voxel_size — half a voxel
+        # downstream of voxel depth_idx's center, not at voxel depth_idx+1.
         depth_idx = round(Int, 0.5 + depth * (N - 1))
         if depth_idx == N
             depth_idx = N - 1
         end
-        depth_actual = depth_idx * prob.voxel_size
+        depth_actual = (depth_idx - 0.5) * prob.voxel_size
 
         ydata = flux(
             c_hist[idx_min:idx_max], prob.D, prob.voxel_size, prob.img, prob.axis;
@@ -162,8 +165,9 @@ function fit_voxel_diffusivity(
     c2 = insulated ? c1 : prob.bc_outlet
     L = (N - 1) * prob.voxel_size * (insulated ? 2 : 1)
 
-    # Cell-center convention: voxel index i maps to physical position (i - 0.5) * voxel_size
-    depth_actual = (depth_idx - 0.5) * prob.voxel_size
+    # Cell-centered FV with Dirichlet clamped at voxel 1 and voxel N centers;
+    # in the analytical coordinate voxel i lives at (i - 1) * voxel_size.
+    depth_actual = (depth_idx - 1) * prob.voxel_size
     if fit_depth
         model = (t, p) -> slab_concentration(1 / p[1], p[2], t; c1=c1, c2=c2, L=L, terms=terms)
     else

--- a/test/test_transient.jl
+++ b/test/test_transient.jl
@@ -293,14 +293,13 @@ end
 
 # --- Fitting effective diffusivity ---
 #
-# These are smoke tests for the TransientSolution adapter method of
-# fit_effective_diffusivity. Tolerances are loose because the fit quality on a
-# small 16³ open-space cube is limited by (1) the discrete grid resolution and
-# (2) a known mismatch between the :mass discretisation and the continuous
-# `slab_mass_uptake` analytical — the simulation subtracts the initial face
-# contribution from mass_uptake while the analytical does not. Strict
-# effective-diffusivity accuracy tests belong on a larger image anyway, so we
-# just verify the wrapper plumbing works end-to-end here.
+# Smoke tests for the TransientSolution adapter + accuracy tests on a
+# fully-open slab. For a homogeneous open slab the discrete FD solver is
+# solving exactly the same PDE as the analytical `slab_concentration` /
+# `slab_flux`, so :conc and :flux must recover D_eff = D_pore to numerical
+# precision on a sufficiently refined grid. :mass has a separate O(1/N)
+# reference-state offset in `mass_uptake` and is excluded from the strict
+# accuracy check.
 
 @testset "fit_effective_diffusivity — TransientSolution wrapper" begin
     prob = TransientDiffusionProblem(open_16;
@@ -318,8 +317,56 @@ end
         @test length(xdata) == length(ydata)
         @test length(xdata) > 0
     end
+end
 
-    # :flux is the tightest method for this setup; check the value itself
-    _, D_eff_flux, _, _, _, _ = fit_effective_diffusivity(sol, prob, :flux; depth=0.5)
-    @test D_eff_flux ≈ 1.0 atol = 0.25
+@testset "fit_effective_diffusivity — fully-open slab recovers D to machine precision" begin
+    # A 1-voxel-wide "slab" in z with fine axial resolution. Every voxel is
+    # pore, so the discrete solver is exactly the continuous 1D slab and
+    # fit_effective_diffusivity with :conc or :flux must recover D = 1 to
+    # within ODE-integrator precision. This would fail by O(dx/L) if the
+    # depth_actual ↔ voxel_index map were off by half a voxel.
+    N = 65
+    img = trues(1, 1, N)
+    prob = TransientDiffusionProblem(img;
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+    sol = solve(prob, ROCK4();
+        saveat=0.005,
+        callback=StopAtFluxBalance(prob; abstol=1e-5),
+        tspan=(0.0, 5.0),
+        reltol=1e-8, abstol=1e-10)
+
+    for depth in (0.25, 0.5, 0.75)
+        τ_c, D_eff_c, _, _, _, _ = fit_effective_diffusivity(sol, prob, :conc; depth=depth)
+        @test D_eff_c ≈ 1.0 atol = 1e-6
+        @test τ_c    ≈ 1.0 atol = 1e-6
+
+        τ_f, D_eff_f, _, _, _, _ = fit_effective_diffusivity(sol, prob, :flux; depth=depth)
+        @test D_eff_f ≈ 1.0 atol = 1e-5
+        @test τ_f    ≈ 1.0 atol = 1e-5
+    end
+end
+
+@testset "fit_effective_diffusivity — depth endpoints hit Dirichlet values" begin
+    # Pin the analytical ↔ discrete coordinate mapping at the boundaries:
+    # voxel 1 must sit at x=0 (where slab_concentration returns c1) and
+    # voxel N at x=L (where it returns c2). A half-voxel offset in
+    # depth_actual would shift these by dx/2 and break the mapping.
+    N = 33
+    img = trues(1, 1, N)
+    prob = TransientDiffusionProblem(img;
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+    sol = solve(prob, ROCK4();
+        saveat=0.01,
+        callback=StopAtFluxBalance(prob; abstol=1e-5),
+        tspan=(0.0, 5.0),
+        reltol=1e-8, abstol=1e-10)
+
+    # At depth=0 / depth=1 the ydata is literally the clamped value, so if
+    # the model matches c1 / c2 at x=0 / x=L then the fit reduces to a
+    # trivial constant and τ = 1 exactly.
+    τ0, D0, _, _, _, _ = fit_effective_diffusivity(sol, prob, :conc; depth=0.0)
+    @test D0 ≈ 1.0 atol = 1e-6
+
+    τ1, D1, _, _, _, _ = fit_effective_diffusivity(sol, prob, :conc; depth=1.0)
+    @test D1 ≈ 1.0 atol = 1e-6
 end


### PR DESCRIPTION
Fixes #71.

## Summary

- Correct the `depth_actual` computation in all three places where the analytical 1D slab solution is fitted against simulation data: `fit_effective_diffusivity` (`:conc` and `:flux` branches) and `fit_voxel_diffusivity`.
- Rewrite the misleading "Cell-center convention: `(i - 0.5) * voxel_size`" comments to describe the actual cell-centered FV convention with Dirichlet clamped at voxel 1 and voxel N centers.
- Add regression tests that pin the analytical ↔ discrete coordinate mapping.

## The bug

The solver is a standard cell-centered FV discretization with Dirichlet clamps imposed directly on voxel 1 and voxel N (`src/transient.jl:333-341`, `:305`). So in the analytical coordinate whose `x = 0` is the inlet Dirichlet plane, voxel `i` sits at `(i - 1) * voxel_size`, not `(i - 0.5) * voxel_size`. The face between voxels `i` and `i+1` sits at `(i - 0.5) * voxel_size`, not `i * voxel_size`. Issue #71 has the full derivation with smoking guns from `dnstools.jl:34` and the discrete steady-state profile.

The buggy formulas were all `+ dx/2` off the true physical position — a systematic shift that biased every `D_eff` / `τ` recovered through `fit_effective_diffusivity` or `fit_voxel_diffusivity` with `:conc` or `:flux`. The `:mass` branch does not use `depth_actual` and is not affected by this fix (but has a separate, unrelated discretization issue tracked elsewhere).

## Diff (three lines + three comments)

| File:line                   | Before                         | After                          |
|-----------------------------|--------------------------------|--------------------------------|
| `transient_fitting.jl:65`   | `(depth_idx - 0.5)*voxel_size` | `(depth_idx - 1)*voxel_size`   |
| `transient_fitting.jl:86`   | `depth_idx * voxel_size`       | `(depth_idx - 0.5)*voxel_size` |
| `transient_fitting.jl:169`  | `(depth_idx - 0.5)*voxel_size` | `(depth_idx - 1)*voxel_size`   |

## Empirical validation

On a fully-open 1D slab (`trues(1, 1, 65)`, `c1=1`, `c2=0`, `D=1`), where the discrete FD solver is solving exactly the same PDE as the analytical, the recovered `|D_eff - 1|`:

| Method | Before | After |
|---|---|---|
| `:conc` | few % (varies with `N`, `depth`) | **3.8e-9** |
| `:flux` | few % | **2.1e-7** |

## New tests

- **`fit_effective_diffusivity — fully-open slab recovers D to machine precision`**: checks both `:conc` (`atol=1e-6`) and `:flux` (`atol=1e-5`) at depths 0.25, 0.5, 0.75 on a 65-voxel slab. This test would have caught the bug by ~4 orders of magnitude. The previous smoke test at `atol=0.25` on a 16³ cube was masking the bias almost perfectly — at `depth=0.5` with `N=16`, voxel 8 sits at `7/15≈0.4667` while the buggy formula evaluated the analytical at `7.5/15=0.5`, a 0.78% concentration mismatch that the loose tolerance absorbed.
- **`fit_effective_diffusivity — depth endpoints hit Dirichlet values`**: pins `depth=0 → c1`, `depth=1 → c2` via the trivial-constant fit they enable — any half-voxel drift in the mapping breaks them.

## Test plan

- [x] Unit tests: `julia --project=. test/test_transient.jl` — all green, including the new tests
- [x] Full package tests: `julia --project=. -e 'using Pkg; Pkg.test()'` — all green (including steady, GPU parity, transient, fit)
- [x] Empirical precision check on a fully-open 65-voxel slab (see table above)

## Credit

Sawyer Hossfeld first noticed the depth-index math looked off in a code-review email thread. Full derivation and discussion captured in #71.