### PR TITLE
perf: precompile GPU paths, fix CPU transient dtype

### DIFF
--- a/ext/TortuosityAMDGPUExt.jl
+++ b/ext/TortuosityAMDGPUExt.jl
@@ -4,6 +4,7 @@ module TortuosityAMDGPUExt
 using AMDGPU
 using Tortuosity
 using KernelAbstractions
+using PrecompileTools: @setup_workload, @compile_workload
 
 function __init__()
     if AMDGPU.functional()
@@ -13,5 +14,29 @@ function __init__()
 end
 
 Tortuosity._on_gpu(::ROCArray) = true
+
+# Mirror the CPU precompile workload in src/Tortuosity.jl for the ROCm GPU path.
+# Only runs when an AMDGPU device is actually present at extension-precompile
+# time; on machines without a GPU it's a no-op and users pay full TTFX on
+# first solve.
+@setup_workload begin
+    if AMDGPU.functional()
+        img = ones(Bool, 12, 12, 12)
+        @compile_workload begin
+            Tortuosity._preferred_gpu_backend[] = ROCBackend()
+            Tortuosity._gpu_adapt[] = AMDGPU.roc
+            try
+                sim = Tortuosity.SteadyDiffusionProblem(img; axis=:x, gpu=true)
+                Tortuosity.solve(sim.prob, Tortuosity.KrylovJL_CG())
+
+                prob = Tortuosity.TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=true)
+                Tortuosity.solve(prob, Tortuosity.ROCK4(); saveat=0.1, tspan=(0.0, 0.2))
+            finally
+                Tortuosity._preferred_gpu_backend[] = nothing
+                Tortuosity._gpu_adapt[] = identity
+            end
+        end
+    end
+end
 
 end

--- a/ext/TortuosityCUDAExt.jl
+++ b/ext/TortuosityCUDAExt.jl
@@ -9,6 +9,7 @@ using Tortuosity: PortableSparseCSC
 using KernelAbstractions
 using LinearAlgebra
 using SparseArrays
+using PrecompileTools: @setup_workload, @compile_workload
 
 function __init__()
     if CUDA.functional()
@@ -71,6 +72,31 @@ function LinearAlgebra.mul!(
     alpha::Number, beta::Number,
 ) where {Tv,Ti,V<:CuVector,Vi<:CuVector}
     return mul!(y, _as_cusparse(A), x, alpha, beta)
+end
+
+# Mirror the CPU precompile workload in src/Tortuosity.jl for the CUDA GPU path.
+# Only runs when a CUDA device is actually present at extension-precompile time;
+# on machines without a GPU it's a no-op and users pay full TTFX on first solve.
+# Note: `__init__` hasn't run yet during precompile, so we register the backend
+# refs manually inside the workload and restore them after.
+@setup_workload begin
+    if CUDA.functional()
+        img = ones(Bool, 12, 12, 12)
+        @compile_workload begin
+            Tortuosity._preferred_gpu_backend[] = CUDABackend()
+            Tortuosity._gpu_adapt[] = CUDA.cu
+            try
+                sim = Tortuosity.SteadyDiffusionProblem(img; axis=:x, gpu=true)
+                Tortuosity.solve(sim.prob, Tortuosity.KrylovJL_CG())
+
+                prob = Tortuosity.TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=true)
+                Tortuosity.solve(prob, Tortuosity.ROCK4(); saveat=0.1, tspan=(0.0, 0.2))
+            finally
+                Tortuosity._preferred_gpu_backend[] = nothing
+                Tortuosity._gpu_adapt[] = identity
+            end
+        end
+    end
 end
 
 end

--- a/ext/TortuosityMetalExt.jl
+++ b/ext/TortuosityMetalExt.jl
@@ -4,6 +4,7 @@ module TortuosityMetalExt
 using Metal
 using Tortuosity
 using KernelAbstractions
+using PrecompileTools: @setup_workload, @compile_workload
 
 function __init__()
     if Metal.functional()
@@ -13,5 +14,28 @@ function __init__()
 end
 
 Tortuosity._on_gpu(::MtlArray) = true
+
+# Mirror the CPU precompile workload in src/Tortuosity.jl for the Metal GPU path.
+# Only runs when a Metal device is actually present at extension-precompile time;
+# on machines without a GPU it's a no-op and users pay full TTFX on first solve.
+@setup_workload begin
+    if Metal.functional()
+        img = ones(Bool, 12, 12, 12)
+        @compile_workload begin
+            Tortuosity._preferred_gpu_backend[] = MetalBackend()
+            Tortuosity._gpu_adapt[] = Metal.mtl
+            try
+                sim = Tortuosity.SteadyDiffusionProblem(img; axis=:x, gpu=true)
+                Tortuosity.solve(sim.prob, Tortuosity.KrylovJL_CG())
+
+                prob = Tortuosity.TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=true)
+                Tortuosity.solve(prob, Tortuosity.ROCK4(); saveat=0.1, tspan=(0.0, 0.2))
+            finally
+                Tortuosity._preferred_gpu_backend[] = nothing
+                Tortuosity._gpu_adapt[] = identity
+            end
+        end
+    end
+end
 
 end

--- a/src/Tortuosity.jl
+++ b/src/Tortuosity.jl
@@ -94,7 +94,7 @@ export slab_cumulative_flux
     effective_diffusivity(c, img; axis=:x)
     formation_factor(c, img; axis=:x)
 
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, dtype=Float32)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0)
     tsol = solve(prob, ROCK4(); saveat=0.1, tspan=(0.0, 0.2))
     flux(tsol.u, prob.D, prob.voxel_size, prob.img, prob.axis; ind=1, pore_index=prob.pore_index)
     mass_uptake(tsol.u, prob)

--- a/src/transient.jl
+++ b/src/transient.jl
@@ -60,7 +60,7 @@ end
 
 """
     TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0,
-                              D=1.0, voxel_size=nothing, dtype=Float32, gpu=nothing)
+                              D=1.0, voxel_size=nothing, gpu=nothing)
 
 Construct a `TransientDiffusionProblem` describing transient diffusion through a
 3D voxelized porous material. The input `img` defines which voxels are pore
@@ -85,11 +85,11 @@ along one axis.
 - `voxel_size`: physical spacing between adjacent voxel centers. If `nothing`,
   it is set to `1/(N_axis - 1)` so that the domain spans `[0, 1]` along the
   chosen axis.
-- `dtype`: numeric type used for the operator and solution arrays (e.g.,
-  `Float32` or `Float64`). Default: `Float32`.
 - `gpu`: whether to run the solver on the GPU. If `nothing` (default), uses
   GPU when a backend package is loaded *and* the image has ≥ 100 000 pore
   voxels. See [GPU backends](@ref) for how to activate CUDA, Metal, or AMDGPU.
+  The element type follows `gpu`: `Float64` on CPU, `Float32` on GPU — the
+  same convention as `SteadyDiffusionProblem`.
 """
 function TransientDiffusionProblem(
     img;
@@ -98,7 +98,6 @@ function TransientDiffusionProblem(
     bc_outlet::BoundValue=0,
     D=1.0,
     voxel_size=nothing,
-    dtype=Float32,
     gpu=nothing,
 )
     img = atleast_3d(img)
@@ -111,10 +110,6 @@ function TransientDiffusionProblem(
     end
     img = BitArray(img .!= 0)
     @assert D isa Number || size(img) == size(D) "For scalar field D, size should match img size"
-    D = D isa Number ? dtype(D) : dtype.(D)
-
-    bc_inlet = _validate_bc(bc_inlet, dtype, "bc_inlet")
-    bc_outlet = _validate_bc(bc_outlet, dtype, "bc_outlet")
 
     nnodes = count(img)
     @assert nnodes > 0 "Image must contain at least one pore voxel (got all-solid)"
@@ -135,6 +130,11 @@ function TransientDiffusionProblem(
                Load a GPU package first (e.g. `using CUDA`, `using Metal`, or `using AMDGPU`).")
     end
 
+    T = gpu ? Float32 : Float64
+    D = D isa Number ? T(D) : T.(D)
+    bc_inlet = _validate_bc(bc_inlet, T, "bc_inlet")
+    bc_outlet = _validate_bc(bc_outlet, T, "bc_outlet")
+
     @assert size(img, axis_dim(axis)) > 1 "Image must have at least 2 voxels along the chosen axis"
     isnothing(voxel_size) && (voxel_size = 1 / (size(img, axis_dim(axis)) - 1))
 
@@ -144,13 +144,13 @@ function TransientDiffusionProblem(
     return TransientDiffusionProblem(voxel_size, D, img, pidx, axis, bc_inlet, bc_outlet, A)
 end
 
-function _validate_bc(bc, dtype, name)
+function _validate_bc(bc, ::Type{T}, name) where {T}
     if bc isa Function
         val = bc(0.0)
         @assert val isa Number "$name(t) must return a Number"
         return bc
     elseif bc isa Number
-        return dtype(bc)
+        return T(bc)
     else
         return nothing
     end

--- a/test/test_gpu_e2e.jl
+++ b/test/test_gpu_e2e.jl
@@ -99,7 +99,7 @@ end
     )
     (any(img[:, :, 1]) && any(img[:, :, end])) || return
 
-    prob = TransientDiffusionProblem(img; axis=:z, gpu=true, dtype=Float32)
+    prob = TransientDiffusionProblem(img; axis=:z, gpu=true)
     @test prob.img isa AbstractArray{Bool}
     @test !_on_gpu(prob.img)
     @test prob.A isa PortableSparseCSC
@@ -119,11 +119,11 @@ end
     )
     (any(img[:, :, 1]) && any(img[:, :, end])) || return
 
-    prob_cpu = TransientDiffusionProblem(img; axis=:z, gpu=false, dtype=Float64)
+    prob_cpu = TransientDiffusionProblem(img; axis=:z, gpu=false)
     sol_cpu = solve(prob_cpu, ROCK4(); saveat=0.05, tspan=(0.0, 0.15))
     c_mean_cpu = sum(sol_cpu.u[end]) / length(sol_cpu.u[end])
 
-    prob_gpu = TransientDiffusionProblem(img; axis=:z, gpu=true, dtype=Float32)
+    prob_gpu = TransientDiffusionProblem(img; axis=:z, gpu=true)
     sol_gpu = solve(prob_gpu, ROCK4(); saveat=0.05, tspan=(0.0, 0.15))
     c_mean_gpu = sum(sol_gpu.u[end]) / length(sol_gpu.u[end])
 

--- a/test/test_transient.jl
+++ b/test/test_transient.jl
@@ -94,7 +94,7 @@ blob_8 = BitArray(Imaginator.blobs(; shape=(8, 8, 8), porosity=0.5, blobiness=1,
 end
 
 @testset "TransientDiffusionProblem — custom parameters" begin
-    prob = TransientDiffusionProblem(blob_8; axis=:x, bc_inlet=2, bc_outlet=0, D=0.5, dtype=Float64, gpu=false)
+    prob = TransientDiffusionProblem(blob_8; axis=:x, bc_inlet=2, bc_outlet=0, D=0.5, gpu=false)
     @test prob.axis == :x
     @test prob.bc_inlet == 2.0
     @test prob.D == 0.5
@@ -126,7 +126,7 @@ end
 
 @testset "Operator — Dirichlet rows are zeroed" begin
     img = ones(Bool, (4, 4, 4))
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=false)
     A = prob.A
     bc_nodes = find_boundary_nodes(prob.img, :bottom)
     append!(bc_nodes, find_boundary_nodes(prob.img, :top))
@@ -137,7 +137,7 @@ end
 
 @testset "Operator — insulated boundary rows are NOT zeroed" begin
     img = ones(Bool, (4, 4, 4))
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=nothing, gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=nothing, gpu=false)
     A = prob.A
     outlet_nodes = find_boundary_nodes(prob.img, :top)
     for node in outlet_nodes
@@ -149,7 +149,7 @@ end
 
 @testset "apply_boundaries! — Dirichlet on both faces" begin
     img = ones(Bool, (4, 4, 4))
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=0, gpu=false)
     c0 = zeros(Float64, size(img))
     apply_boundaries!(c0, prob)
     @test all(c0[:, :, 1] .== 1.0)
@@ -158,7 +158,7 @@ end
 
 @testset "apply_boundaries! — insulated outlet" begin
     img = ones(Bool, (4, 4, 4))
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=nothing, gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=1, bc_outlet=nothing, gpu=false)
     c0 = zeros(Float64, size(img))
     apply_boundaries!(c0, prob)
     @test all(c0[:, :, 1] .== 1.0)
@@ -168,7 +168,7 @@ end
 @testset "apply_boundaries! — time-dependent inlet" begin
     img = ones(Bool, (4, 4, 4))
     f_inlet = t -> 0.5 + t
-    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=f_inlet, bc_outlet=0, gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(img; axis=:z, bc_inlet=f_inlet, bc_outlet=0, gpu=false)
     c0 = zeros(Float64, size(img))
     apply_boundaries!(c0, prob)
     @test all(c0[:, :, 1] .== 0.5)  # f(0) = 0.5
@@ -178,7 +178,7 @@ end
 # --- Solve + TransientSolution ---
 
 @testset "solve — basic time progression" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     sol = solve(prob, ROCK4(); saveat=0.1, tspan=(0.0, 0.5))
     @test sol.t[end] >= 0.5
     @test length(sol.t) > 1
@@ -187,13 +187,13 @@ end
 end
 
 @testset "solve — sol.u is CPU even under GPU-style code path" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     sol = solve(prob, ROCK4(); saveat=0.1, tspan=(0.0, 0.5))
     @test all(u isa Vector{Float64} for u in sol.u)
 end
 
 @testset "TransientSolution — show" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     sol = solve(prob, ROCK4(); saveat=0.2, tspan=(0.0, 0.5))
     io = IOBuffer()
     show(io, sol)
@@ -206,7 +206,7 @@ end
 # --- Stop conditions ---
 
 @testset "StopAtSteadyState — terminates on small du/dt" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.1,
         callback=StopAtSteadyState(abstol=1e-4, reltol=1e-3),
@@ -216,7 +216,7 @@ end
 end
 
 @testset "StopAtSaturation — terminates at target mean" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     target = 0.3
     sol = solve(prob, ROCK4();
         saveat=0.05,
@@ -228,7 +228,7 @@ end
 end
 
 @testset "StopAtFluxBalance — terminates near steady state" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.1,
         callback=StopAtFluxBalance(prob; abstol=0.05),
@@ -248,7 +248,7 @@ end
         axis=:z,
         bc_inlet=t -> (sin(2π * freq * t) + 1) / 2,
         bc_outlet=nothing,
-        gpu=false, dtype=Float64)
+        gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.05,
         callback=StopAtPeriodicState(freq, prob; reltol=1e-3),
@@ -261,7 +261,7 @@ end
 # --- Composed callbacks ---
 
 @testset "CallbackSet — compose stop condition with tspan cap" begin
-    prob = TransientDiffusionProblem(blob_8; gpu=false, dtype=Float64)
+    prob = TransientDiffusionProblem(blob_8; gpu=false)
     # Extremely tight tolerance so the callback shouldn't fire before tspan end
     sol = solve(prob, ROCK4();
         saveat=0.1,
@@ -277,7 +277,7 @@ open_16 = ones(Bool, (16, 16, 16))
 
 @testset "Open space transient — $(ax)-axis" for ax in (:x, :y, :z)
     prob = TransientDiffusionProblem(open_16;
-        axis=ax, bc_inlet=1, bc_outlet=0, gpu=false, dtype=Float64)
+        axis=ax, bc_inlet=1, bc_outlet=0, gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.05,
         callback=StopAtFluxBalance(prob; abstol=0.01),
@@ -304,7 +304,7 @@ end
 
 @testset "fit_effective_diffusivity — TransientSolution wrapper" begin
     prob = TransientDiffusionProblem(open_16;
-        axis=:z, bc_inlet=1, bc_outlet=0, gpu=false, dtype=Float64)
+        axis=:z, bc_inlet=1, bc_outlet=0, gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.02,
         callback=StopAtFluxBalance(prob; abstol=0.001),
@@ -329,7 +329,7 @@ end
     N = 65
     img = trues(1, 1, N)
     prob = TransientDiffusionProblem(img;
-        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.005,
         callback=StopAtFluxBalance(prob; abstol=1e-5),
@@ -355,7 +355,7 @@ end
     N = 33
     img = trues(1, 1, N)
     prob = TransientDiffusionProblem(img;
-        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.01,
         callback=StopAtFluxBalance(prob; abstol=1e-5),
@@ -384,7 +384,7 @@ end
     for N in (17, 33, 65, 129)
         img = trues(1, 1, N)
         prob = TransientDiffusionProblem(img;
-            axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+            axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false)
         sol = solve(prob, ROCK4();
             saveat=0.01,
             tspan=(0.0, 10.0),
@@ -408,7 +408,7 @@ end
     N = 33
     img = trues(1, 1, N)
     prob = TransientDiffusionProblem(img;
-        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false)
     sol = solve(prob, ROCK4(); saveat=0.01, tspan=(0.0, 10.0),
                 reltol=1e-10, abstol=1e-12)
 
@@ -446,7 +446,7 @@ end
     N = 33
     img = trues(1, 1, N)
     prob = TransientDiffusionProblem(img;
-        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false, dtype=Float64)
+        axis=:z, bc_inlet=1.0, bc_outlet=0.0, gpu=false)
     sol = solve(prob, ROCK4();
         saveat=0.01,
         callback=StopAtFluxBalance(prob; abstol=1e-8),


### PR DESCRIPTION
Bundled two things that both touch the precompile path. The second one is the small fix; the first is the actual feature.

## 1. GPU precompile workloads (the main thing)

#75 cut CPU TTFX by ~95% via `@compile_workload` in `src/Tortuosity.jl`, but that workload was intentionally CPU-only. The GPU path still paid full codegen cost on first solve — I measured **~52 s** on a cold `using CUDA; using Tortuosity` + first steady solve on an RTX 3060. None of that was kernel work; it's all LinearSolve / Krylov / CUSPARSE type specialisation that the CPU workload can't cover.

Fix is the standard PrecompileTools pattern: each package extension (`TortuosityCUDAExt`, `TortuosityAMDGPUExt`, `TortuosityMetalExt`) now carries its own `@setup_workload` / `@compile_workload` that runs steady + transient on a 12³ image, guarded by the backend's `*.functional()`. Machines without a GPU skip the workload entirely and behave exactly as before.

One non-obvious bit: the extension's `__init__` hasn't run yet at extension-precompile time, so `_preferred_gpu_backend[]` and `_gpu_adapt[]` are still `nothing`. The workload sets them manually and restores them in a `finally`.

### Measured impact (CUDA, RTX 3060, Julia 1.12.5, 32³ blob)

|                                   | Before | After  |   Δ   |
| --------------------------------- | -----: | -----: | ----: |
| `using CUDA; using Tortuosity`    | 6.05 s | 6.88 s |  +0.8 |
| First steady solve TTFX           | 51.7 s | 6.05 s | **-88%** |
| Second solve (cached)             |  35 ms |  35 ms |    ─  |
| Time-to-first-τ (end-to-end)      |   58 s |   13 s | **-78%** |

Cost side: CUDA extension precompile went from ~7 s to ~78 s, once per Tortuosity version, paid only when CUDA is actually present. ROCm and Metal are structurally identical — I couldn't bench them but the pattern is the same.

## 2. Fix `TransientDiffusionProblem` dtype default on CPU — closes #77

Spotted this while looking at the CPU workload to mirror it on GPU. `TransientDiffusionProblem` took a `dtype` kwarg defaulting to `Float32` regardless of CPU/GPU, which contradicted `docs/design.md:160`:

> `SteadyDiffusionProblem` and `TransientDiffusionProblem` use `Float32` for all arrays when `gpu=true` and `Float64` when `gpu=false`.

So CPU users were silently getting Float32 precision they never asked for. I dropped the kwarg entirely and hard-coded `T = gpu ? Float32 : Float64` to match `SteadyDiffusionProblem` (see `src/simulations.jl:132`).

Side effects:
- Every CPU transient test was passing `dtype=Float64` as a workaround — ~20 call sites in `test/test_transient.jl`, 3 more in `test/test_gpu_e2e.jl`. All deleted as dead kwargs.
- The CPU precompile workload in `src/Tortuosity.jl:97` was passing `dtype=Float32`, which meant the CPU workload from #75 was specialising for a dtype CPU users never hit on the transient path. Removed — the CPU workload now correctly compiles for Float64.

Strictly an API break (kwarg removal), but the package is v0.0.5 and every in-repo caller was either ignoring the kwarg or using it as a workaround for the bug we're fixing, so nobody's real intent gets overridden. More detail in #77.

## Why one PR, not two

Both changes touch the precompile path, and the GPU workload was going to land on whatever CPU default I had — running GPU precompile on top of a buggy transient default would've baked specialisations for a code path that's itself about to change. Cleaner to fix the default first and precompile against the corrected code. Kept the dtype fix in its own commit message section so it's still easy to bisect.

## Verified

- `Pkg.test()`: full suite (340 + 374 + 44 GPU e2e) passes
- CUDA extension precompile succeeds with the new workload (~78 s one-time)
- Cold-start TTFX numbers in the table above, two runs each, consistent
- `examples/demo_transient.jl` runs end-to-end (covered by the test suite's "Example scripts" block)

Closes #77.