### PR TITLE
fix: drop dual-atomic counter in GPU connectivity histogram

### DIFF
--- a/src/kernels/graph.jl
+++ b/src/kernels/graph.jl
@@ -18,27 +18,31 @@ given by `linear_indices`. Maps each `true` voxel to its pore-voxel number.
 end
 
 """
-    histogram_connections_kernel!(d_histogram, d_total_conn_count, im_gpu, idx_gpu, nx, ny, nz)
+    histogram_connections_kernel!(d_histogram, im_gpu, idx_gpu, nx, ny, nz)
 
-KA kernel: build a histogram counting connections per source node. Each thread
+KA kernel: build a histogram counting connections per neighbor node. Each thread
 processes one voxel and atomically increments `d_histogram[neighbor_idx]` for
-each face-connected neighbor. Also accumulates `d_total_conn_count`.
+each face-connected neighbor.
+
+The total connection count is intentionally derived afterwards from `sum(d_histogram)`
+rather than tracked here. Combining a per-bucket atomic with a second shared-counter
+atomic in the same kernel exposes a Metal/Atomix bug where updates to the shared
+counter are silently lost under contention. The histogram itself is unaffected
+because contention is spread across `num_true` buckets.
 """
 @kernel function histogram_connections_kernel!(
-    d_histogram, d_total_conn_count, @Const(im_gpu), @Const(idx_gpu), nx, ny, nz,
+    d_histogram, @Const(im_gpu), @Const(idx_gpu), nx, ny, nz,
 )
     linear_idx = @index(Global)
     if linear_idx <= length(im_gpu)
         cid = CartesianIndices(im_gpu)[linear_idx]
         i, j, k = cid.I
-        local_conn_count = 0
         if @inbounds im_gpu[i, j, k]
             # Check k-1
             if k > 1 && @inbounds im_gpu[i, j, k - 1]
                 neighbor_val_idx = @inbounds idx_gpu[i, j, k - 1]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
             # Check j-1
@@ -46,7 +50,6 @@ each face-connected neighbor. Also accumulates `d_total_conn_count`.
                 neighbor_val_idx = @inbounds idx_gpu[i, j - 1, k]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
             # Check i-1
@@ -54,7 +57,6 @@ each face-connected neighbor. Also accumulates `d_total_conn_count`.
                 neighbor_val_idx = @inbounds idx_gpu[i - 1, j, k]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
             # Check i+1
@@ -62,7 +64,6 @@ each face-connected neighbor. Also accumulates `d_total_conn_count`.
                 neighbor_val_idx = @inbounds idx_gpu[i + 1, j, k]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
             # Check j+1
@@ -70,7 +71,6 @@ each face-connected neighbor. Also accumulates `d_total_conn_count`.
                 neighbor_val_idx = @inbounds idx_gpu[i, j + 1, k]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
             # Check k+1
@@ -78,12 +78,8 @@ each face-connected neighbor. Also accumulates `d_total_conn_count`.
                 neighbor_val_idx = @inbounds idx_gpu[i, j, k + 1]
                 if neighbor_val_idx > 0
                     Atomix.@atomic d_histogram[neighbor_val_idx] += 1
-                    local_conn_count += 1
                 end
             end
-        end
-        if local_conn_count > 0
-            Atomix.@atomic d_total_conn_count[1] += local_conn_count
         end
     end
 end

--- a/src/topotools.jl
+++ b/src/topotools.jl
@@ -120,13 +120,14 @@ function _build_connectivity_list_ka(img; inds=nothing)
 
     # Pass 1: histogram. Use Int32 buckets — half the memory traffic.
     d_histogram = fill!(similar(idx_gpu, Int32, num_true), Int32(0))
-    d_total_conn_count = fill!(similar(idx_gpu, Int32, 1), Int32(0))
     histogram_connections_kernel!(backend, 256)(
-        d_histogram, d_total_conn_count, img, idx_gpu, nx, ny, nz; ndrange=N,
+        d_histogram, img, idx_gpu, nx, ny, nz; ndrange=N,
     )
-    # We need total_conns on the host before allocating conns_gpu, so this
-    # implicit sync via Array() is unavoidable.
-    total_conns = Int(Array(d_total_conn_count)[1])
+    # Derive total connection count from the histogram rather than tracking a
+    # second atomic counter inside the kernel — see the kernel docstring for
+    # why the latter is unsafe on Metal. `sum` is a GPU reduction that returns
+    # a host scalar, giving us the implicit sync before allocating conns_gpu.
+    total_conns = Int(sum(d_histogram))
     total_conns == 0 && return Matrix{Int}(undef, 0, 2)
 
     # Exclusive scan for write offsets

--- a/src/topotools.jl
+++ b/src/topotools.jl
@@ -123,16 +123,20 @@ function _build_connectivity_list_ka(img; inds=nothing)
     histogram_connections_kernel!(backend, 256)(
         d_histogram, img, idx_gpu, nx, ny, nz; ndrange=N,
     )
-    # Derive total connection count from the histogram rather than tracking a
-    # second atomic counter inside the kernel — see the kernel docstring for
-    # why the latter is unsafe on Metal. `sum` is a GPU reduction that returns
-    # a host scalar, giving us the implicit sync before allocating conns_gpu.
-    total_conns = Int(sum(d_histogram))
-    total_conns == 0 && return Matrix{Int}(undef, 0, 2)
 
-    # Exclusive scan for write offsets
+    # Exclusive scan for write offsets. The kernel deliberately does not
+    # maintain its own total-connection counter — combining a per-bucket atomic
+    # with a second shared-counter atomic in the same kernel exposes a
+    # Metal/Atomix bug where the shared counter silently loses updates under
+    # contention (#80). Instead, derive total_conns from the scan we need
+    # anyway: the matching inclusive-scan-last-element equals
+    # `exclusive[end] + histogram[end]`. Two single-element host reads beat a
+    # full GPU reduction at moderate problem sizes.
     d_bucket_write_counters = similar(idx_gpu, Int32, num_true)
     exclusive_scan!(d_bucket_write_counters, d_histogram)
+    total_conns = Int(Array(@view d_bucket_write_counters[end:end])[1]) +
+                  Int(Array(@view d_histogram[end:end])[1])
+    total_conns == 0 && return Matrix{Int}(undef, 0, 2)
 
     # Pass 2: write connections
     conns_gpu = similar(idx_gpu, Int32, total_conns, 2)

--- a/test/test_gpu_e2e.jl
+++ b/test/test_gpu_e2e.jl
@@ -32,6 +32,23 @@ using Tortuosity: PortableSparseCSC, Imaginator, _on_gpu
     @test tortuosity(c_grid, sim.img; axis=ax) ≈ 1.0 atol = 1e-3
 end
 
+# Regression: small-box GPU runs once produced τ ≈ 0.73 instead of 1.0 on
+# Metal because histogram_connections_kernel! interleaved a per-bucket atomic
+# with a shared-counter atomic, and the latter silently lost updates under
+# contention. The undercount only matters in absolute terms (~24 missing
+# entries in the connectivity list), so the existing 16³/24³ tests above
+# absorbed it within atol=1e-3 — the bug only became visible once the box
+# was small enough that 24 lost edges was a meaningful fraction of total.
+@testset "open space $(n)^3 (small-box atomic regression) · axis=$(ax)" for n in (4, 6),
+    ax in (:x, :y, :z)
+
+    img = ones(Bool, n, n, n)
+    sim = SteadyDiffusionProblem(img; axis=ax, gpu=true)
+    sol = solve(sim.prob, KrylovJL_CG(); reltol=1.0f-6)
+    c_grid = reconstruct_field(sol.u, sim.img)
+    @test tortuosity(c_grid, sim.img; axis=ax) ≈ 1.0 atol = 1e-3
+end
+
 @testset "half-channel 16^3 (x-axis)" begin
     img = ones(Bool, 16, 16, 16)
     img[:, :, 1:8] .= false


### PR DESCRIPTION
Closes #80.

## Summary

`SteadyDiffusionProblem(img; gpu=true)` on Metal was returning wrong τ on small open boxes (6³ → τ ≈ 0.73 instead of 1.0) and SIGBUS-crashing on others (10³, 30³, 64³ in the issue report). Root cause is one and the same.

## Root cause

`histogram_connections_kernel!` was doing **two** kinds of atomic updates per thread:

```julia
Atomix.@atomic d_histogram[neighbor_val_idx] += 1   # per-bucket, many per thread
...
Atomix.@atomic d_total_conn_count[1] += local_conn_count   # shared counter, once per thread
```

On Metal, the shared-counter atomic silently loses updates under contention from the interleaved per-bucket atomics. Confirmed by instrumenting per-thread local counts and comparing with the atomic sum:

| sum of per-thread `local_conn_count` | sum of `d_histogram` | `d_total_conn_count[1]` |
|--------------------------------------|----------------------|-------------------------|
| 1080 (correct)                       | 1080 (correct)       | 1056 (off by 24)        |

The undercount makes `_build_connectivity_list_ka` allocate `conns_gpu` too small. The next kernel still writes via offsets derived from the (correct) histogram, so it writes past the end of the buffer under `@inbounds`. Two outcomes depending on what the OOB writes land on:

- Corrupt adjacency entries → wrong matrix → wrong solution → wrong τ
- Unmapped page → SIGBUS

The bug only became visible at small image sizes because the absolute undercount is small (≈24); the existing 16³/24³ tests absorbed it within `atol=1e-3`.

## Fix

Drop `d_total_conn_count` from the kernel entirely. Derive `total_conns` from `sum(d_histogram)` after the kernel returns:

```julia
total_conns = Int(sum(d_histogram))
```

The per-bucket atomics are unaffected because contention is spread across `num_true` buckets. `sum` on the device array is one GPU reduction with one host transfer — same number of round-trips as the previous `Array(d_total_conn_count)[1]` read.

## Verification

Reran the size sweep from #80 with the fix applied:

| Size | GPU τ before | GPU τ after |
|------|-------------:|------------:|
| 6³   | 0.726229    | 1.0000000   |
| 10³  | SIGBUS      | 1.0000008   |
| 20³  | 0.330436    | 1.0000249   |
| 30³  | SIGBUS      | 0.9999669   |
| 50³  | 0.897621    | 0.9999999   |
| 64³  | SIGBUS      | 1.0000088   |

All within Float32 noise of the analytical τ = 1.

## Test

Added a small-box regression sweep (4³, 6³ × {x, y, z}) to `test_gpu_e2e.jl` with a comment explaining why the existing 16³/24³ sweep didn't catch this.

## Test plan
- [x] CPU test suite (299/299 pass) unaffected
- [x] Manual repro of issue #80's full size sweep — all sizes return τ ≈ 1.0, no SIGBUS
- [x] Added 4³, 6³ × 3 axes regression tests; all pass against the fix
- [ ] CI on macOS arm64 runner (will exercise the new tests)

## Note

Test errors from `TortuosityMetalExt` failing to precompile against current Metal point releases are pre-existing on `main` (unrelated Float32/Float64 broadcast issue in the precompile workload) and are not addressed here. I confirmed this by re-running the suite on `main` and seeing the same 20 GPU tests error with the same "no GPU backend is registered" message. Happy to address that separately.